### PR TITLE
dark: add serializable to the handler params

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,9 @@ class User implements Serializable
 The `serializes` method returns an array of the properties that you want to serialize. Then the package will automatically serialize and deserialize the data based on the type
 hinted properties.
 
-> Note: The package will only serialize public properties that are type hinted.
+> **Note** 
+> - The package will only serialize public properties that are type hinted.
+> - The package will serialize properties in the order they are defined in the `serialize` method. 
 
 ### Serialization Handlers
 
@@ -72,7 +74,7 @@ class UserHandler implements SerializationHandler {
         $this->userRepository = $userRepository;
     }
 
-    public function serialize($value): string
+    public function serialize(Serializable $serializable, $value): string
     {
         return $value->getId();
     }
@@ -82,7 +84,7 @@ class UserHandler implements SerializationHandler {
      *
      * @return ?User
      */
-    public function deserialize($value): ?User
+    public function deserialize(Serializable $serializable, $value): ?User
     {
         return $this->userRepository->find($value);
     }

--- a/src/Contracts/SerializationHandler.php
+++ b/src/Contracts/SerializationHandler.php
@@ -9,12 +9,12 @@ interface SerializationHandler
      *
      * @return mixed
      */
-    public function serialize($value);
+    public function serialize(Serializable $serializable, $value);
 
     /**
      * @param mixed $value
      *
      * @return mixed
      */
-    public function deserialize($value);
+    public function deserialize(Serializable $serializable, $value);
 }

--- a/src/Laravel/ModelSerializationHandler.php
+++ b/src/Laravel/ModelSerializationHandler.php
@@ -2,8 +2,10 @@
 
 namespace YouCanShop\Cereal\Laravel;
 
+use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+use YouCanShop\Cereal\Contracts\Serializable;
 use YouCanShop\Cereal\Contracts\SerializationHandler;
 
 final class ModelSerializationHandler implements SerializationHandler
@@ -13,19 +15,19 @@ final class ModelSerializationHandler implements SerializationHandler
     /**
      * @param Model $value
      *
-     * @return mixed
+     * @return ModelIdentifier|mixed
      */
-    public function serialize($value)
+    public function serialize(Serializable $serializable, $value)
     {
         return $this->getSerializedPropertyValue($value);
     }
 
     /**
-     * @param $value
+     * @param ModelIdentifier|mixed $value
      *
      * @return mixed
      */
-    public function deserialize($value)
+    public function deserialize(Serializable $serializable, $value)
     {
         return $this->getRestoredPropertyValue($value);
     }

--- a/src/SerializationHandlerFactory.php
+++ b/src/SerializationHandlerFactory.php
@@ -25,6 +25,7 @@ final class SerializationHandlerFactory
         return self::$instance;
     }
 
+    
     public function getHandler(string $type): SerializationHandler
     {
         if (!isset($this->handlers[$type])) {

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -53,7 +53,10 @@ final class Serializer
 
             $this->serializations[$propertyName] = $this->getSerializationHandlerFactory()
                 ->getHandler($type->getName())
-                ->serialize($this->serializable->$propertyName);
+                ->serialize(
+                    $this->serializable,
+                    $this->serializable->$propertyName
+                );
         }
     }
 
@@ -98,7 +101,10 @@ final class Serializer
 
             $this->serializable->$propertyName = $this->getSerializationHandlerFactory()
                 ->getHandler($type->getName())
-                ->deserialize($serialized);
+                ->deserialize(
+                    $this->serializable,
+                    $serialized
+                );
         }
     }
 }


### PR DESCRIPTION
### Notes

- Pass the `Serializable` instance to the handler's methods
- Ensure serialization is done in the order of property definition